### PR TITLE
require cmake >= 3.1 instead of 3.0

### DIFF
--- a/ewoms-buildfiles/CMakeLists.txt
+++ b/ewoms-buildfiles/CMakeLists.txt
@@ -1,7 +1,7 @@
 # -*- mode: cmake; tab-width: 2; indent-tabs-mode: t; truncate-lines: t
 # vim: set filetype=cmake autoindent tabstop=2 shiftwidth=2 noexpandtab softtabstop=2 nowrap:
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.1)
 
 # set up project and specify the minimum cmake version
 project("ewoms" C CXX)

--- a/opm-common-buildfiles/CMakeLists.txt
+++ b/opm-common-buildfiles/CMakeLists.txt
@@ -1,7 +1,7 @@
 # -*- mode: cmake; tab-width: 2; indent-tabs-mode: t; truncate-lines: t
 # vim: set filetype=cmake autoindent tabstop=2 shiftwidth=2 noexpandtab softtabstop=2 nowrap:
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.1)
 
 # set up project
 project("opm-common" C CXX)

--- a/opm-core-buildfiles/CMakeLists.txt
+++ b/opm-core-buildfiles/CMakeLists.txt
@@ -1,7 +1,7 @@
 # -*- mode: cmake; tab-width: 2; indent-tabs-mode: t; truncate-lines: t
 # vim: set filetype=cmake autoindent tabstop=2 shiftwidth=2 noexpandtab softtabstop=2 nowrap:
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.1)
 
 # set up project and specify the minimum cmake version
 project("opm-core" C CXX)

--- a/opm-grid-buildfiles/CMakeLists.txt
+++ b/opm-grid-buildfiles/CMakeLists.txt
@@ -1,7 +1,7 @@
 # -*- mode: cmake; tab-width: 2; indent-tabs-mode: t; truncate-lines: t
 # vim: set filetype=cmake autoindent tabstop=2 shiftwidth=2 noexpandtab softtabstop=2 nowrap:
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.1)
 
 # set up project and specify the minimum cmake version
 project("opm-grid" C CXX)

--- a/opm-material-buildfiles/CMakeLists.txt
+++ b/opm-material-buildfiles/CMakeLists.txt
@@ -1,7 +1,7 @@
 # -*- mode: cmake; tab-width: 2; indent-tabs-mode: t; truncate-lines: t
 # vim: set filetype=cmake autoindent tabstop=2 shiftwidth=2 noexpandtab softtabstop=2 nowrap:
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.1)
 
 # set up project and specify the minimum cmake version
 project("opm-material" C CXX)

--- a/opm-output-buildfiles/CMakeLists.txt
+++ b/opm-output-buildfiles/CMakeLists.txt
@@ -1,7 +1,7 @@
 # -*- mode: cmake; tab-width: 2; indent-tabs-mode: t; truncate-lines: t
 # vim: set filetype=cmake autoindent tabstop=2 shiftwidth=2 noexpandtab softtabstop=2 nowrap:
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.1)
 
 # set up project and specify the minimum cmake version
 project("opm-output" C CXX)

--- a/opm-simulators-buildfiles/CMakeLists.txt
+++ b/opm-simulators-buildfiles/CMakeLists.txt
@@ -1,7 +1,7 @@
 # -*- mode: cmake; tab-width: 2; indent-tabs-mode: t; truncate-lines: t
 # vim: set filetype=cmake autoindent tabstop=2 shiftwidth=2 noexpandtab softtabstop=2 nowrap:
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.1)
 
 # set up project and specify the minimum cmake version
 project("opm-simulators" C CXX)

--- a/opm-upscaling-buildfiles/CMakeLists.txt
+++ b/opm-upscaling-buildfiles/CMakeLists.txt
@@ -1,7 +1,7 @@
 # -*- mode: cmake; tab-width: 2; indent-tabs-mode: t; truncate-lines: t
 # vim: set filetype=cmake autoindent tabstop=2 shiftwidth=2 noexpandtab softtabstop=2 nowrap:
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.1)
 
 # set up project and specify the minimum cmake version
 project("opm-upscaling" C CXX)


### PR DESCRIPTION
cmake 3.1 seems to become the default for dune 2.6 because earlier versions apparently have bugs which make the dune build system fail in some cases. I won't argue with that, so let's follow their lead.