### PR TITLE
add support for opm-parser

### DIFF
--- a/bin/cmake-wrapper.sh
+++ b/bin/cmake-wrapper.sh
@@ -115,6 +115,7 @@ EOF
 get_source_dir
 extract_module_name
 case "$MODULE_NAME" in
+    "opm-parser" | \
     "opm-common" | \
     "opm-output" | \
     "opm-grid" | \

--- a/opm-material-buildfiles/cmake/modules/OpmMaterialMacros.cmake
+++ b/opm-material-buildfiles/cmake/modules/OpmMaterialMacros.cmake
@@ -11,8 +11,3 @@ if(QUADMATH_FOUND)
   dune_register_package_flags(
     LIBRARIES "${QUADMATH_LIBRARIES}")
 endif()
-
-# this is a hack to make config.h work as advertised
-if(ecl_FOUND)
-  set(HAVE_ERT 1)
-endif()

--- a/opm-parser-buildfiles/CMakeLists.txt
+++ b/opm-parser-buildfiles/CMakeLists.txt
@@ -53,6 +53,10 @@ opm_add_headers_library_and_executables("opmparser")
 target_link_libraries("opmparser" "${Boost_REGEX_LIBRARIES}" "${Boost_SYSTEM_LIBRARIES}" "${Boost_FILESYSTEM_LIBRARIES}")
 include_directories("${PROJECT_BINARY_DIR}/include")
 
+if (BUILD_TESTING)
+  include(ExtraTests.cmake)
+endif()
+
 if(TARGET opmi)
   target_link_libraries(opmi ${Boost_LIBRARIES})
 endif()

--- a/opm-parser-buildfiles/CMakeLists.txt
+++ b/opm-parser-buildfiles/CMakeLists.txt
@@ -1,0 +1,63 @@
+# -*- mode: cmake; tab-width: 2; indent-tabs-mode: t; truncate-lines: t
+# vim: set filetype=cmake autoindent tabstop=2 shiftwidth=2 noexpandtab softtabstop=2 nowrap:
+
+cmake_minimum_required(VERSION 3.1)
+
+# set up project and specify the minimum cmake version
+project("opm-parser" C CXX)
+
+# find the build system (i.e., dune-common) and set cmake's module path
+find_package(dune-common REQUIRED)
+list(APPEND CMAKE_MODULE_PATH ${dune-common_MODULE_PATH})
+
+# include the dune macros
+include(DuneMacros)
+
+# start a dune project with information from dune.module
+dune_project()
+
+# include the OPM cmake macros
+include(OpmMacros)
+
+# find the packages needed to compile the module
+find_package(Boost COMPONENTS regex system filesystem unit_test_framework REQUIRED)
+
+# we want all features detected by the build system to be enabled,
+# thank you!
+dune_enable_all_packages()
+
+# Add json library
+set(opmjson_SOURCES
+  "lib/json/JsonObject.cpp"
+  "${PROJECT_SOURCE_DIR}/external/cjson/cJSON.c")
+
+list(APPEND MAIN_SOURCE_FILES "${opmjson_SOURCES}")
+add_library(opmjson ${opmjson_SOURCES})
+target_link_libraries(opmjson PUBLIC ${Boost_FILESYSTEM_LIBRARY})
+target_include_directories(opmjson PUBLIC "${PROJECT_SOURCE_DIR}/lib/json/include" "${PROJECT_SOURCE_DIR}/external/cjson")
+
+# Keyword generator
+include(GenerateKeywords.cmake)
+
+# Append generated sources
+list(APPEND MAIN_SOURCE_FILES ${PROJECT_BINARY_DIR}/ParserKeywords.cpp)
+
+# read in the file lists of CMakeLists_files.txt and remove the files
+# which should not have been added.
+opm_read_listsfile()
+
+add_definitions(-DBOOST_TEST_DYN_LINK=1)
+
+opm_add_headers_library_and_executables("opmparser")
+
+target_link_libraries("opmparser" "${Boost_REGEX_LIBRARIES}" "${Boost_SYSTEM_LIBRARIES}" "${Boost_FILESYSTEM_LIBRARIES}")
+include_directories("${PROJECT_BINARY_DIR}/include")
+
+if(TARGET opmi)
+  target_link_libraries(opmi ${Boost_LIBRARIES})
+endif()
+
+opm_recusive_copy_testdata("tests/*.data" "tests/*.DATA")
+
+# finalize the dune project, e.g. generating config.h etc.
+finalize_dune_project(GENERATE_CONFIG_H_CMAKE)

--- a/opm-parser-buildfiles/cmake/Modules/CheckCaseSensitiveFileSystem.cmake
+++ b/opm-parser-buildfiles/cmake/Modules/CheckCaseSensitiveFileSystem.cmake
@@ -1,0 +1,29 @@
+#
+# Module to check whether the file system is case sensitive or not
+#
+# Sets the following variable:
+#
+# HAVE_CASE_SENSITIVE_FILESYSTEM   True if the file system honors the case of files
+
+message(STATUS "Checking whether the file system is case-sensitive")
+# create a file containing uppercase characters
+file(WRITE "${CMAKE_BINARY_DIR}/UPPER" "Foo")
+
+# check if the all-lowercase file with the same name can be opened
+set(FooContents "")
+if (EXISTS "${CMAKE_BINARY_DIR}/upper")
+    file(READ "${CMAKE_BINARY_DIR}/upper" FooContents)
+endif()
+
+# remove the file again in order not to have it dangling around...
+file(REMOVE "${CMAKE_BINARY_DIR}/UPPER")
+
+# check the contents of the file opened with lower-case. If it is
+# empty, the file system is case sensitive.
+if ("${FooContents}" STREQUAL "Foo")
+  message(STATUS "File system is not case-sensitive")
+  set(HAVE_CASE_SENSITIVE_FILESYSTEM 0)
+else()
+  message(STATUS "File system is case-sensitive")
+  set(HAVE_CASE_SENSITIVE_FILESYSTEM 1)
+endif()

--- a/opm-parser-buildfiles/cmake/modules/OpmParserMacros.cmake
+++ b/opm-parser-buildfiles/cmake/modules/OpmParserMacros.cmake
@@ -1,0 +1,43 @@
+# .. cmake_module::
+#
+# This module's content is executed whenever a Dune module requires or
+# suggests opm-parser!
+#
+
+find_package(ecl REQUIRED)
+if(NOT TARGET ecl)
+  message(FATAL_ERROR "libecl not found!")
+endif()
+  
+# Need to grab from target to enable transitional depends
+get_target_property(ecl_INCLUDE_DIRS ecl INTERFACE_INCLUDE_DIRECTORIES)
+get_target_property(ecl_LIBRARIES ecl INTERFACE_LINK_LIBRARIES)
+get_target_property(ecl_lib ecl LOCATION)
+set(ecl_LIBRARIES ${ecl_lib} ${ecl_LIBRARIES})
+set(ecl_FOUND 1)
+
+dune_register_package_flags(
+  LIBRARIES "${ecl_LIBRARIES}"
+  INCLUDE_DIRS "${ecl_INCLUDE_DIRS}")
+  
+# this is a hack that is required for the non-standard locations of
+# header files in opm-parser
+if (DEFINED opm-parser_SOURCE_DIR)
+  dune_register_package_flags(
+    INCLUDE_DIRS
+    "${opm-parser_SOURCE_DIR}/lib/json/include"
+    "${opm-parser_SOURCE_DIR}/external/cjson"
+    "${opm-parser_SOURCE_DIR}/lib/eclipse/include")
+else()
+  foreach(CAND
+      "${opm-parser_PREFIX}/lib/json/include"
+      "${opm-parser_PREFIX}/external/cjson"
+      "${opm-parser_PREFIX}/lib/eclipse/include"
+      "${opm-parser_DIR}/include")
+
+    if (IS_DIRECTORY "${CAND}")
+      dune_register_package_flags(INCLUDE_DIRS "${CAND}")
+    endif()
+
+  endforeach()
+endif()

--- a/opm-parser-buildfiles/config.h.cmake
+++ b/opm-parser-buildfiles/config.h.cmake
@@ -1,0 +1,50 @@
+/* begin opm-parser
+   put the definitions for config.h specific to
+   your project here. Everything above will be
+   overwritten
+*/
+/* begin private */
+/* Name of package */
+#define PACKAGE "@DUNE_MOD_NAME@"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "@DUNE_MAINTAINER@"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "@DUNE_MOD_NAME@"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "@DUNE_MOD_NAME@ @DUNE_MOD_VERSION@"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "@DUNE_MOD_NAME@"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL "@DUNE_MOD_URL@"
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "@DUNE_MOD_VERSION@"
+
+/* end private */
+
+/* Define to the version of opm-parser */
+#define OPM_PARSER_VERSION "${OPM_PARSER_VERSION}"
+
+/* Define to the major version of opm-parser */
+#define OPM_PARSER_VERSION_MAJOR ${OPM_PARSER_VERSION_MAJOR}
+
+/* Define to the minor version of opm-parser */
+#define OPM_PARSER_VERSION_MINOR ${OPM_PARSER_VERSION_MINOR}
+
+/* Define to the revision of opm-parser */
+#define OPM_PARSER_VERSION_REVISION ${OPM_PARSER_VERSION_REVISION}
+
+/* Specify whether libecl is available or not */
+#define HAVE_LIBECL 1
+#define HAVE_ERT 1 /* <- deprecated! */
+
+/* begin bottom */
+
+/* end bottom */
+
+/* end opm-parser */

--- a/opm-parser-buildfiles/opm-parser.pc.in
+++ b/opm-parser-buildfiles/opm-parser.pc.in
@@ -1,0 +1,15 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+CXX=@CXX@
+CC=@CC@
+DEPENDENCIES=@REQUIRES@
+
+Name: @PACKAGE_NAME@
+Version: @VERSION@
+Description: The opm-parser module
+URL: http://www.opm-project.org/
+Requires: ${DEPENDENCIES}
+Libs: -L${libdir}
+Cflags: -I${includedir}


### PR DESCRIPTION
the custom build system of opm-parser recently has been removed, so we need to pick up the slack. this is not very pretty -- mainly because the code generator needs to be called during the build and because the
opm-parser file locations are quite non OPM-standard --, but for now it seems to work well enough until the next module layout refactoring happens.

note that this PR must **NOT** be merged right now but only if/when the default opm-parser build system has been changed to the one from opm-common!