### PR TITLE
fix a few papercuts

### DIFF
--- a/ewoms-buildfiles/CMakeLists.txt
+++ b/ewoms-buildfiles/CMakeLists.txt
@@ -74,7 +74,12 @@ opm_add_test(art2dgf
 # EQUIL init tests
 opm_add_test(test_equil
   DRIVER_ARGS --plain
-  CONDITION opm-grid_FOUND AND opm-parser_FOUND)
+  CONDITION opm-grid_FOUND AND opm-parser_FOUND AND opm-grid_FOUND)
+
+# Output ECL tests
+opm_add_test(test_ecl_output
+             DRIVER_ARGS --plain
+             CONDITION opm-parser_FOUND AND opm-grid_FOUND AND opm-output_FOUND)
 
 # add targets for all tests of the models. we add the water-air test
 # first because it take longest and so that we don't have to wait for

--- a/ewoms-buildfiles/config.h.cmake
+++ b/ewoms-buildfiles/config.h.cmake
@@ -42,9 +42,6 @@
 /* Define to the codename of ewoms */
 #define EWOMS_VERSION_CODENAME "${EWOMS_VERSION_CODENAME}"
 
-/* Specify whether quadruple precision floating point arithmetics are available */
-#cmakedefine HAVE_QUAD 1
-
 /* begin bottom */
 
 /* end bottom */

--- a/opm-material-buildfiles/CMakeLists.txt
+++ b/opm-material-buildfiles/CMakeLists.txt
@@ -32,7 +32,7 @@ dune_enable_all_packages()
 
 # add all unit tests
 opm_add_test(test_blackoilfluidstate)
-#opm_add_test(test_ConditionalStorage)
+opm_add_test(test_ConditionalStorage)
 opm_add_test(test_eclblackoilfluidsystem CONDITION opm-parser_FOUND)
 opm_add_test(test_eclblackoilpvt CONDITION opm-parser_FOUND)
 opm_add_test(test_eclmateriallawmanager CONDITION opm-parser_FOUND)

--- a/opm-material-buildfiles/config.h.cmake
+++ b/opm-material-buildfiles/config.h.cmake
@@ -42,6 +42,9 @@
 /* Define whether the ERT/libecl libraries are available */
 #cmakedefine HAVE_ERT 1
 
+/* Specify whether quadruple precision floating point arithmetics are available */
+#cmakedefine HAVE_QUAD 1
+
 /* begin bottom */
 
 /* end bottom */


### PR DESCRIPTION
- the HAVE_QUADMATH macro ought to be set by the opm-material config.h
  because the find module is called from there.
- enable the ConditionalStorage test in opm-material
- add the test_ecl_output test in eWoms
- fix the condition for test_equil in eWoms

@dr-robertk: this PR can be merged immediately.